### PR TITLE
TCXB6-10197: Error in opening webpa_cfg.json

### DIFF
--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -480,6 +480,10 @@ void loadCfgFile()
 	int flag = 0;
 	size_t sz;
 	fp = fopen(WEBPA_CFG_FILE, "r");
+        if (chmod(WEBPA_CFG_FILE, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH) < 0)
+	{
+                WalError("Could not set mode 0666 on %s\n",WEBPA_CFG_FILE);
+        }
 	if (fp == NULL)
 	{
 		WalError("Failed to open cfg file in read mode creating new file %s\n", WEBPA_CFG_FILE);


### PR DESCRIPTION
Reason for change: Write permission for all - /nvram/webpa_cfg.json
Test Procedure: Verify that firmware version details to WebPA config file
Risks: Low

Signed-off-by: Indhuja Avinashi Valliammal Sivasamy <indhuja_avinashivalliammalsivasamy@comcast.com>