### PR TITLE
RDKBDEV-1191 parodus2ccsp: ApplySettings is not triggered for MAC Filter tables added via WebPA

### DIFF
--- a/source/broadband/webpa_parameter.c
+++ b/source/broadband/webpa_parameter.c
@@ -44,7 +44,7 @@ static void free_paramVal_memory(param_t ** val, int paramCount);
 static int prepare_parameterValueStruct(parameterValStruct_t* val, param_t *paramVal, char *paramName);
 static int setParamValues(param_t *paramVal, char *CompName, char *dbusPath, int paramCount,const WEBPA_SET_TYPE setType, char *transactionId);
 static void *applyWiFiSettingsTask();
-static void identifyRadioIndexToReset(int paramCount, parameterValStruct_t* val,BOOL *bRestartRadio1,BOOL *bRestartRadio2,BOOL *bRestartRadio3); 
+void identifyRadioIndexToReset(int paramCount, parameterValStruct_t* val,BOOL *bRestartRadio1,BOOL *bRestartRadio2,BOOL *bRestartRadio3); 
 BOOL applySettingsFlag;
 #ifdef WEBCONFIG_BIN_SUPPORT
 #define WEBCFG_FORCE_SYNC_PARAM "Device.X_RDK_WebConfig.ForceSync"
@@ -702,7 +702,6 @@ static int setParamValues(param_t *paramVal, char *CompName, char *dbusPath, int
         if(!strcmp(CompName,RDKB_WIFI_FULL_COMPONENT_NAME) && setType != WEBPA_ATOMIC_SET_WEBCONFIG)
         {
                 identifyRadioIndexToReset(paramCount,val,&bRestartRadio1,&bRestartRadio2,&bRestartRadio3);
-                bRadioRestartEn = TRUE;
         }
 
         if(strcmp(CompName, RDKB_WEBPA_FULL_COMPONENT_NAME) == 0)
@@ -817,7 +816,7 @@ static int setParamValues(param_t *paramVal, char *CompName, char *dbusPath, int
  * @param[out] bRestartRadio2
  * @param[out] bRestartRadio3
  */
-static void identifyRadioIndexToReset(int paramCount, parameterValStruct_t* val,BOOL *bRestartRadio1,BOOL *bRestartRadio2,BOOL *bRestartRadio3) 
+void identifyRadioIndexToReset(int paramCount, parameterValStruct_t* val,BOOL *bRestartRadio1,BOOL *bRestartRadio2,BOOL *bRestartRadio3) 
 {
 	int x =0 ,index =0, SSID =0,apply_rf =0;
 	for (x = 0; x < paramCount; x++)
@@ -884,6 +883,7 @@ static void identifyRadioIndexToReset(int paramCount, parameterValStruct_t* val,
 			}
 		}
 	}
+    bRadioRestartEn = TRUE;
 }
 
 /**

--- a/source/broadband/webpa_table.c
+++ b/source/broadband/webpa_table.c
@@ -21,6 +21,13 @@
 /*----------------------------------------------------------------------------*/
 
 /*----------------------------------------------------------------------------*/
+/*                            Extern Scoped Variables                         */
+/*----------------------------------------------------------------------------*/
+extern pthread_cond_t applySetting_cond;
+extern BOOL bRestartRadio1;
+extern BOOL bRestartRadio2;
+
+/*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
 
@@ -234,6 +241,11 @@ int updateRow(char *objectName,TableData *list,char *compName,char *dbusPath)
         if((ret != CCSP_SUCCESS) && (faultParam != NULL))
         {
             WAL_FREE(faultParam);
+        }
+        if(!strcmp(compName,RDKB_WIFI_FULL_COMPONENT_NAME))
+        {
+            identifyRadioIndexToReset(numParam,val,&bRestartRadio1,&bRestartRadio2);
+            pthread_cond_signal(&applySetting_cond);
         }
     }
     else


### PR DESCRIPTION
Reason for change: 1) parodus_receive() is receiving the webpa query and passing message to processRequest()
for adding the table
2) addRowTable() creating table and IndexMpa_WEBPAtoCPE() is using maping the Index values
3) addRow() adding row and updated the configurations by using updateRow()
4) CcspBaseIf_setParameterValues() using to set the data models and its not setting bRadioRestartEn flag for the
apply settings
 Root cause: There is no code flow for Apply setting once configured WiFi Mac filter table rules,
 resultant, mac address is not updating in HAL list

Test Procedure: Added Mac filter table via WebPA and confirmed that the apply settings is triggered and
params are rippled down to WiFi HAL

Risks: None

Signed-off-by: Mohamed Shaikh <mohamed.shaikh@t-systems.com>