### PR TITLE
RDKBDEV-1192 parodus2ccsp: ApplySettings is not triggered for MAC Filter table deletion

### DIFF
--- a/source/broadband/webpa_table.c
+++ b/source/broadband/webpa_table.c
@@ -264,6 +264,8 @@ int deleteRow(char *object)
     char dst_pathname_cr[MAX_PATHNAME_CR_LEN] = { 0 };
     char l_Subsystem[MAX_DBUS_INTERFACE_LEN] = { 0 };
     componentStruct_t ** ppComponents = NULL;
+    parameterValStruct_t val;
+    memset(&val, 0, sizeof(val));
 #if !defined(RDKB_EMU)
     strncpy(l_Subsystem, "eRT.",sizeof(l_Subsystem));
 #endif
@@ -294,6 +296,15 @@ int deleteRow(char *object)
     {
         WalPrint("Execution succeed.\n");
         WalInfo("%s is deleted.\n", object);
+        if(!strcmp(compName,RDKB_WIFI_FULL_COMPONENT_NAME))
+        {
+           val.parameterName=(char *) malloc(sizeof(char ) * MAX_PARAMETERNAME_LEN);
+           snprintf(val.parameterName,MAX_PARAMETERNAME_LEN,"%s",object);
+           val.parameterName[MAX_PARAMETERNAME_LEN-1] = '\0';
+           identifyRadioIndexToReset(1,&val,&bRestartRadio1,&bRestartRadio2);
+           pthread_cond_signal(&applySetting_cond);
+           WAL_FREE(val.parameterName);
+        }
     }
     else
     {


### PR DESCRIPTION
…ter table deletion

Steps followed :
1. FR the device and should come up.
2. Configure wifi SSID and password for both 2.4 and 5ghz. and connect 2 clients to 2.4 ghz.
3. By default there should not be any MAC table.
Device.WiFi.AccessPoint.1.X_CISCO_COM_MacFilterTable.
4. Set the filter to allow mode.
Device.WiFi.AccessPoint.1.X_CISCO_COM_MACFilter.
5. Add the MAC filter table and details of connected client.
Device.WiFi.AccessPoint.1.X_CISCO_COM_MacFilterTable.
6. The MAC added in table should get connect and Other clients should not get connect.
7. Check the MAC details of WLANs.
wifi_api wifi_getApAclDevices 0
8. Delete all MAC tables.
9. Now check the MAC details.
wifi_api wifi_getApAclDevices 0
10. The MAC table should be empty and any client should not get connect.
Actual Result :
7. Displaying the MAC details of added clients.
8. Getting deleted the tables.
9. Still showing the MAC details of previously added clients.
10. The clients which we deleted the table are getting connected.
Expected Result :
7. Displaying the MAC details of added clients.
8. Getting deleted the table.
9. Should not show any MAC details.
10. Any client Should not get connect.

Signed-off-by: Mohamed Shaikh <mohamed.shaikh@t-systems.com>