### PR TITLE
LTE-783: Use eth0 MAC as deviceMAC for XLE

### DIFF
--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -796,6 +796,20 @@ void getDeviceMac()
         {	    
             backoffRetryTime = (int) pow(2, c) -1;
 #ifdef RDKB_BUILD
+#ifdef _WNXL11BWL_PRODUCT_REQ_
+            FILE *pFile = fopen("/sys/class/net/eth0/address", "r");
+            if (pFile)
+            {
+                char eth0Mac[18] = {0};
+
+            	fread(ethMac, 1, sizeof(eth0Mac) - 1, pFile);
+            	fclose(pFile);
+
+            	pthread_mutex_lock(&device_mac_mutex);
+                macToLower(eth0Mac, deviceMAC);
+                WalInfo("XLE deviceMAC is %s\n", deviceMAC);
+            }
+#else
             token_t  token;
             int fd = s_sysevent_connect(&token);
             if(WDMP_SUCCESS == check_ethernet_wan_status() && sysevent_get(fd, token, "eth_wan_mac", deviceMACValue, sizeof(deviceMACValue)) == 0 && deviceMACValue[0] != '\0')
@@ -805,6 +819,7 @@ void getDeviceMac()
                 WalInfo("deviceMAC is %s\n", deviceMAC);
             }
             else
+#endif
 #endif
             {
 		pthread_mutex_lock(&device_mac_mutex);

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -802,7 +802,7 @@ void getDeviceMac()
             {
                 char eth0Mac[18] = {0};
 
-            	fread(ethMac, 1, sizeof(eth0Mac) - 1, pFile);
+            	fread(eth0Mac, 1, sizeof(eth0Mac) - 1, pFile);
             	fclose(pFile);
 
             	pthread_mutex_lock(&device_mac_mutex);


### PR DESCRIPTION
XLE does not have a cable modem, so it was decided to use eth0 MAC address as "deviceMAC".

Without the fix there are error messages:

WEBPA: device_mac is empty, unable to get cloud_status