### PR TITLE
LTE-783: Provide the deviceMAC from another source.

### DIFF
--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -796,6 +796,20 @@ void getDeviceMac()
         {	    
             backoffRetryTime = (int) pow(2, c) -1;
 #ifdef RDKB_BUILD
+#ifdef _WNXL11BWL_PRODUCT_REQ_
+            FILE *pFile = fopen("/sys/class/net/eth0/address", "r");
+            if (pFile)
+            {
+                char eth0Mac[18] = {0};
+
+            	fread(ethMac, 1, sizeof(eth0Mac) - 1, pFile);
+            	fclose(pFile);
+
+            	pthread_mutex_lock(&device_mac_mutex);
+                macToLower(eth0Mac, deviceMAC);
+                WalInfo("XLE deviceMAC is %s\n", deviceMAC);
+            }
+#else
             token_t  token;
             int fd = s_sysevent_connect(&token);
             if(WDMP_SUCCESS == check_ethernet_wan_status() && sysevent_get(fd, token, "eth_wan_mac", deviceMACValue, sizeof(deviceMACValue)) == 0 && deviceMACValue[0] != '\0')
@@ -805,6 +819,7 @@ void getDeviceMac()
                 WalInfo("deviceMAC is %s\n", deviceMAC);
             }
             else
+#endif
 #endif
             {
 		pthread_mutex_lock(&device_mac_mutex);

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -797,16 +797,16 @@ void getDeviceMac()
             backoffRetryTime = (int) pow(2, c) -1;
 #ifdef RDKB_BUILD
 #ifdef _WNXL11BWL_PRODUCT_REQ_
-            FILE *pFile = fopen("/sys/class/net/eth0/address", "r");
+            FILE *pFile = popen("deviceinfo.sh -cmac", "r");
             if (pFile)
             {
-                char eth0Mac[18] = {0};
+                char deviceInfoMac[18] = {0};
 
-            	fread(eth0Mac, 1, sizeof(eth0Mac) - 1, pFile);
+            	fread(deviceInfoMac, 1, sizeof(deviceInfoMac) - 1, pFile);
             	fclose(pFile);
 
             	pthread_mutex_lock(&device_mac_mutex);
-                macToLower(eth0Mac, deviceMAC);
+                macToLower(deviceInfoMac, deviceMAC);
                 WalInfo("XLE deviceMAC is %s\n", deviceMAC);
             }
 #else

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -802,7 +802,7 @@ void getDeviceMac()
             {
                 char eth0Mac[18] = {0};
 
-            	fread(ethMac, 1, sizeof(eth0Mac) - 1, pFile);
+            	fread(eth0Mac, 1, sizeof(eth0Mac) - 1, pFile);
             	fclose(pFile);
 
             	pthread_mutex_lock(&device_mac_mutex);

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -797,13 +797,13 @@ void getDeviceMac()
             backoffRetryTime = (int) pow(2, c) -1;
 #ifdef RDKB_BUILD
 #ifdef _WNXL11BWL_PRODUCT_REQ_
-            FILE *pFile = popen("deviceinfo.sh -cmac", "r");
-            if (pFile)
+            FILE *pPipe = popen("deviceinfo.sh -cmac", "r");
+            if (pPipe)
             {
                 char deviceInfoMac[18] = {0};
 
-            	fread(deviceInfoMac, 1, sizeof(deviceInfoMac) - 1, pFile);
-            	fclose(pFile);
+            	fread(deviceInfoMac, 1, sizeof(deviceInfoMac) - 1, pPipe);
+            	pclose(pPipe);
 
             	pthread_mutex_lock(&device_mac_mutex);
                 macToLower(deviceInfoMac, deviceMAC);


### PR DESCRIPTION
XLE does not have a CM, so we need to use a different source of MAC.
There is a common bash script which provides "cmac" (which is actually eth0) so parodus should use it for the XLE platform.