### PR TITLE
Use different DEVICE_MAC name for XLE

### DIFF
--- a/source/broadband/include/webpa_internal.h
+++ b/source/broadband/include/webpa_internal.h
@@ -69,7 +69,7 @@
 #define DEVICE_MAC                   "Device.Ethernet.Interface.5.MACAddress"
 #elif defined(RDKB_EMU)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
-#elif defined(_HUB4_PRODUCT_REQ_)
+#elif defined(_HUB4_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define DEVICE_MAC                   "Device.X_CISCO_COM_CableModem.MACAddress"


### PR DESCRIPTION
LTE-783: "device_mac is empty, unable to get cloud_status" error in webpa We need to use different DEVICE_MAC name for XLE.