### PR TITLE
Added delay to send SYNC notification to fix wifi captive portal issue

### DIFF
--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -1154,6 +1154,9 @@ void processNotification(NotifyData *notifyData)
 	        		cJSON_AddNumberToObject(notifyPayload, "cmc", cmc);
 	        		cJSON_AddStringToObject(notifyPayload, "cid", cid);
 				OnboardLog("%s/%d/%s\n",dest,cmc,cid);
+				//Added delay of 5s to fix wifi captive portal issue where sync notifications are sent before wifi updates the parameter values in device DB
+				WalInfo("Sleeping for 5 sec before sending SYNC_NOTIFICATION\n");
+				sleep(5);
 	        	}
 	        		break;
 


### PR DESCRIPTION
RDKB-51288 Unable to configure the SSID and password through captive portal and admin GUI when webconfig is enabled.
Added delay of 5s to fix wifi captive portal issue where sync notifications are sent before wifi updates the parameter values in device DB.