### PR TITLE
fix: TraceContext crash issue fix for add, replace row request

### DIFF
--- a/source/app/libpd.c
+++ b/source/app/libpd.c
@@ -180,7 +180,7 @@ static void parodus_receive()
                         	res_headers = (headers_t *)malloc(sizeof(headers_t) + sizeof( char * ) * (wrp_msg->u.req.headers->count));
 				if(res_headers != NULL) {
 					WalPrint("Memory allocated successfully for response headers\n");
-					memset(res_headers, 0, sizeof(headers_t));
+					memset(res_headers, 0, (sizeof(headers_t) + sizeof( char * ) * (wrp_msg->u.req.headers->count)));
 				}
 				else {
 					WalError("Memory not allocated for response headers\n");
@@ -203,6 +203,12 @@ static void parodus_receive()
 					}
                                	}
                          }
+			 else if(res_headers != NULL)
+			 {
+				 WalInfo("Deallocating memory for non processing response headers\n");
+				 free(res_headers);
+				 res_headers = NULL;
+			 }			
 		
                         if(res_wrp_msg->u.req.payload !=NULL)
                         {   


### PR DESCRIPTION
CMXB7-6054 : [CXB7] [6.3p15s1] [Videotron] webpa process crashed when parental control is enabled
For Videotron PartnerId, sever is sending ADD_ROW and REPLACE_ROWS Request with TraceContext header.
Webpa will not process TraceContext header for ADD_ROW/REPLACE_ROWS, for fix this issue initialised zero for response header.