### PR TITLE
RDKB-56987: [64BIT] Fix Runtime crash with webpa

### DIFF
--- a/source/broadband/plugin_main_apis.c
+++ b/source/broadband/plugin_main_apis.c
@@ -72,6 +72,10 @@
 #include <webcfg_log.h>
 #endif
 #include "webpa_adapter.h"
+#include "cosa_webpa_internal.h"
+
+extern ANSC_HANDLE CosaWebConfigCreate (VOID);
+extern ANSC_STATUS CosaWebConfigRemove(ANSC_HANDLE hThisObject);
 
 ANSC_HANDLE                        g_MessageBusHandle;
 


### PR DESCRIPTION
webpa process is crashing in 64bit mode against
kirkstone yocto version. The crash was due to pointer corruption as function return type casting to wrong type causing 64bit address truncated to 32bit and eventually pointer corrupted and crash occurred.

Here we could see in caller area, there is implicit function errors which as treated as warning during compilation. This is causing even though functions executed properly but when caller cast it into corresponding type, its return type wrongly mapped and resulted in corruption.

This change is mainly includes include header as well use extern to resolve the problem in casting in the caller area.