### PR TITLE
RDKBDEV-2989: Memory leaks fix

### DIFF
--- a/source/app/main.c
+++ b/source/app/main.c
@@ -10,6 +10,7 @@
 #include "webpa_adapter.h"
 #include "libpd.h"
 #include "webpa_rbus.h"
+#include "cap.h"
 #ifdef FEATURE_SUPPORT_WEBCONFIG
 #include <curl/curl.h>
 #endif

--- a/source/app/privilege.c
+++ b/source/app/privilege.c
@@ -1,6 +1,26 @@
 #include "privilege.h"
+#include "webpa_adapter.h"
+#include "cap.h"
+
+cap_user appcaps;
+bool blocklist_ret = false;
 
 void drop_root_privilege()
 {
-
+   appcaps.caps = NULL;
+   appcaps.user_name = NULL;
+   blocklist_ret = isBlocklisted();
+   if(blocklist_ret)
+   {
+       WalInfo("NonRoot feature is disabled\n");
+   }
+   else
+   {
+       WalInfo("NonRoot feature is enabled, dropping root privileges for webpa process\n");
+       init_capability();
+       drop_root_caps(&appcaps);
+       update_process_caps(&appcaps);
+       read_capability(&appcaps);
+       clear_caps(&appcaps);
+   }
 }

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -541,6 +541,7 @@ void loadCfgFile()
 			{
 				strcpy(webPaCfg.oldFirmwareVersion,"");
 			}
+			cJSON_Delete(webpa_cfg);
 		}
 		else
 		{
@@ -1193,6 +1194,8 @@ void processNotification(NotifyData *notifyData)
 	        		if (ret != WDMP_SUCCESS)
 	        		{
 	        			free(dest);
+	        			cJSON_Delete(notifyPayload);
+	        			freeNotifyMessage(notifyData);
 	        			return;
 	        		}
 	        		cJSON_AddNumberToObject(notifyPayload, "cmc", cmc);
@@ -1215,6 +1218,8 @@ void processNotification(NotifyData *notifyData)
 	        		if (ret != WDMP_SUCCESS)
 	        		{
 	        			free(dest);
+	        			cJSON_Delete(notifyPayload);
+	        			freeNotifyMessage(notifyData);
 	        			return;
 	        		}
 	        		WalPrint("Framing notifyPayload for Factory reset\n");
@@ -1235,12 +1240,15 @@ void processNotification(NotifyData *notifyData)
 	        			if (ret != WDMP_SUCCESS)
 	        			{
 	        				free(dest);
+	        				cJSON_Delete(notifyPayload);
+	        				freeNotifyMessage(notifyData);
 	        				return;
 	        			}
 	        			WalPrint("Framing notifyPayload for Firmware upgrade\n");
 	        			cJSON_AddNumberToObject(notifyPayload, "cmc", cmc);
 	        			cJSON_AddStringToObject(notifyPayload, "cid", cid);
 					OnboardLog("FIRMWARE_UPGRADE/%d/%s\n",cmc,cid);
+	        			WAL_FREE(cid);
 	        		}
 	        			break;
 
@@ -1292,6 +1300,8 @@ void processNotification(NotifyData *notifyData)
 	        		else
 	        		{
 	        			free(dest);
+	        			cJSON_Delete(notifyPayload);
+	        			freeNotifyMessage(notifyData);
 	        			return;
 	        		}
 				OnboardLog("%s/%s\n",dest,notifyData->u.status->transId);

--- a/source/broadband/webpa_parameter.c
+++ b/source/broadband/webpa_parameter.c
@@ -83,6 +83,11 @@ void getValues(const char *paramName[], const unsigned int paramCount, int index
         {
             break;
         }
+        if ((paramCount == 1) && (parameterName[(strlen(parameterName)-1)] == '.'))
+        {
+            count = 1;
+            isLargeWildCard = 0;
+        }
         WalPrint("parameterName: %s count: %d\n",parameterName,count);
         for(i = 0; i < count; i++)
         {
@@ -96,7 +101,6 @@ void getValues(const char *paramName[], const unsigned int paramCount, int index
 
     if(error != 1)
     {
-        isLargeWildCard = 0;
         WalPrint("compCount : %d paramCount: %d\n",compCount,paramCount);
         if(compCount > paramCount)
         {


### PR DESCRIPTION
Reason for change: definitely lost: 548 bytes in 4 blocks
Test Procedure: run valgind with webpabroadband module
Risks: None