### PR TITLE
XER10-1286 - Correct the notfication events for XER10

### DIFF
--- a/source/broadband/include/webpa_internal.h
+++ b/source/broadband/include/webpa_internal.h
@@ -83,7 +83,7 @@
 #define DEVICE_MAC                   "Device.Ethernet.Interface.5.MACAddress"
 #elif defined(RDKB_EMU) || defined(_PLATFORM_BANANAPI_R4_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
-#elif defined(_HUB4_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_)
+#elif defined(_HUB4_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
 #define DEVICE_MAC                   "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define DEVICE_MAC                   "Device.X_CISCO_COM_CableModem.MACAddress"

--- a/source/broadband/webpa_internal.c
+++ b/source/broadband/webpa_internal.c
@@ -62,7 +62,7 @@ char *objectList[] ={
 "Device.NeighborDiscovery.",
 "Device.IPv6rd.",
 "Device.X_CISCO_COM_MLD.",
-#ifndef _HUB4_PRODUCT_REQ_
+#if ! defined(_HUB4_PRODUCT_REQ_) || ! defined(_SCER11BEL_PRODUCT_REQ_)
 #if defined(_COSA_BCM_MIPS_)
 "Device.DPoE.",
 #else
@@ -77,7 +77,7 @@ char *objectList[] ={
 "Device.Hosts.",
 "Device.ManagementServer.",
 "Device.XHosts.",
-#if ! defined(_HUB4_PRODUCT_REQ_) && ! defined(_XER5_PRODUCT_REQ_)
+#if ! defined(_HUB4_PRODUCT_REQ_) && ! defined(_XER5_PRODUCT_REQ_) && ! defined(_SCER11BEL_PRODUCT_REQ_)
 "Device.X_CISCO_COM_MTA.",
 #endif
 "Device.X_RDKCENTRAL-COM_XDNS.",

--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -172,7 +172,7 @@ const char * notifyparameters[]={
 "Device.X_COMCAST-COM_GRE.Tunnel.1.Interface.1.LocalInterfaces",
 "Device.X_COMCAST-COM_GRE.Tunnel.1.Interface.2.VLANID",
 "Device.X_COMCAST-COM_GRE.Tunnel.1.Interface.2.LocalInterfaces",
-#ifdef _HUB4_PRODUCT_REQ_
+#if defined(_HUB4_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
 "Device.NAT.X_CISCO_COM_PortTriggers.Enable",
 "Device.UPnP.Device.UPnPIGD",
 "Device.UserInterface.X_CISCO_COM_RemoteAccess.HttpEnable",


### PR DESCRIPTION
Enable below webpa notifications for XER10:

Device.NAT.X_CISCO_COM_PortTriggers.Enable
Device.UPnP.Device.UPnPIGD
Device.UserInterface.X_CISCO_COM_RemoteAccess.HttpEnable Device.UserInterface.X_CISCO_COM_RemoteAccess.HttpsEnable

Disable below not required notfications for XER10 which are not applicable:
Device.MoCA.
Device.X_CISCO_COM_CableModem.

Signed-off-by: Vysakh A V <vysakhav@protonmail.com>