### PR TITLE
Added delay of 8s in sync notification to fix wifi captive portal in …

### DIFF
--- a/source/broadband/webpa_notification.c
+++ b/source/broadband/webpa_notification.c
@@ -1202,9 +1202,15 @@ void processNotification(NotifyData *notifyData)
 	        		cJSON_AddStringToObject(notifyPayload, "cid", cid);
 				OnboardLog("%s/%d/%s\n",dest,cmc,cid);
                                 WAL_FREE(cid);
+			#if defined(_SCER11BEL_PRODUCT_REQ_)
+                               //XER10-1536: Added delay of 8s in XER10 platform to fix wifi captive portal issue where sync notifications are sent before wifi updates the parameter values in device DB
+				WalInfo("Sleeping for 8 sec before sending SYNC_NOTIFICATION\n");
+				sleep(8);
+			#else
 				//Added delay of 5s to fix wifi captive portal issue where sync notifications are sent before wifi updates the parameter values in device DB
 				WalInfo("Sleeping for 5 sec before sending SYNC_NOTIFICATION\n");
 				sleep(5);
+			#endif
 	        	}
 	        		break;
 


### PR DESCRIPTION
…XER10

Reason for change: Added 8s delay in webpa to send sync notification to cloud to fix wifi captive portal issue where sync notifications are sent before wifi updates the parameter values in device DB.